### PR TITLE
fix "Implicit conversion from float to int loses precision" in PHP 8.2

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
     name: PHP ${{ matrix.php }} Test
 
     steps:

--- a/src/CodeGen.php
+++ b/src/CodeGen.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use function base64_decode;
 use function floor;
 use function hash_hmac;
+use function intval;
 use function pack;
 use function strlen;
 use function unpack;
@@ -65,7 +66,7 @@ class CodeGen
         $code = '';
 
         for ($i = 0; $i < 5; ++$i) {
-            $code .= self::$steamChars[$codePoint % $charLen];
+            $code .= self::$steamChars[intval($codePoint) % $charLen];
             $codePoint /= $charLen;
         }
 


### PR DESCRIPTION
hi! a small fix and added PHP 8.2 to CI.